### PR TITLE
Make it compile on all supported Go platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ go:
   - tip
 scripts:
   - go test
+  - ./compileall.sh

--- a/color.go
+++ b/color.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 )
 
 const Escape = "\x1b"
@@ -54,7 +53,7 @@ func ANSIColor(node *Node, s string) string {
 		} else {
 			style = "1;36"
 		}
-	case mode&(syscall.S_IXUSR|syscall.S_IXGRP|syscall.S_IXOTH) != 0:
+	case mode&modeExecute != 0:
 		style = "1;32"
 	default:
 		return s

--- a/compileall.sh
+++ b/compileall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+while read -r line; do
+    parts=(${line//\// })
+    export GOOS=${parts[0]}
+    export GOARCH=${parts[1]}
+    echo Try GOOS=${GOOS} GOARCH=${GOARCH}
+    go install
+done < <(go tool dist list)

--- a/csort_bsd.go
+++ b/csort_bsd.go
@@ -1,4 +1,5 @@
-// +build amd64,linux
+//+build darwin freebsd netbsd
+
 package tree
 
 import (
@@ -8,5 +9,5 @@ import (
 
 func CTimeSort(f1, f2 os.FileInfo) bool {
 	s1, s2 := f1.Sys().(*syscall.Stat_t), f2.Sys().(*syscall.Stat_t)
-	return s1.Ctim.Sec < s2.Ctim.Sec
+	return s1.Ctimespec.Sec < s2.Ctimespec.Sec
 }

--- a/csort_generic.go
+++ b/csort_generic.go
@@ -1,0 +1,6 @@
+//+build !linux,!openbsd,!dragonfly,!android,!solaris,!darwin,!freebsd,!netbsd
+
+package tree
+
+// CtimeSort for unsupported OS - just compare ModTime
+var CTimeSort = ModSort

--- a/csort_unix.go
+++ b/csort_unix.go
@@ -1,4 +1,5 @@
-// +build amd64,darwin
+//+build linux openbsd dragonfly android solaris
+
 package tree
 
 import (
@@ -8,5 +9,5 @@ import (
 
 func CTimeSort(f1, f2 os.FileInfo) bool {
 	s1, s2 := f1.Sys().(*syscall.Stat_t), f2.Sys().(*syscall.Stat_t)
-	return s1.Ctimespec.Sec < s2.Ctimespec.Sec
+	return s1.Ctim.Sec < s2.Ctim.Sec
 }

--- a/modes_bsd.go
+++ b/modes_bsd.go
@@ -1,0 +1,7 @@
+//+build dragonfly freebsd openbsd solaris windows
+
+package tree
+
+import "syscall"
+
+const modeExecute = syscall.S_IXUSR

--- a/modes_unix.go
+++ b/modes_unix.go
@@ -1,0 +1,7 @@
+//+build android darwin linux nacl netbsd
+
+package tree
+
+import "syscall"
+
+const modeExecute = syscall.S_IXUSR | syscall.S_IXGRP | syscall.S_IXOTH

--- a/modes_unsupported.go
+++ b/modes_unsupported.go
@@ -1,0 +1,5 @@
+//+build !dragonfly,!freebsd,!openbsd,!solaris,!windows,!android,!darwin,!linux,!nacl,!netbsd
+
+package tree
+
+const modeExecute = 0

--- a/node.go
+++ b/node.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // Node represent some node in the tree
@@ -216,33 +215,33 @@ func (node *Node) print(indent string, opts *Options) {
 	}
 	if !node.IsDir() {
 		var props []string
-		var stat = node.Sys().(*syscall.Stat_t)
+		ok, inode, device, uid, gid := getStat(node)
 		// inodes
-		if opts.Inodes {
-			props = append(props, fmt.Sprintf("%d", stat.Ino))
+		if ok && opts.Inodes {
+			props = append(props, fmt.Sprintf("%d", inode))
 		}
 		// device
-		if opts.Device {
-			props = append(props, fmt.Sprintf("%3d", stat.Dev))
+		if ok && opts.Device {
+			props = append(props, fmt.Sprintf("%3d", device))
 		}
 		// Mode
 		if opts.FileMode {
 			props = append(props, node.Mode().String())
 		}
 		// Owner/Uid
-		if opts.ShowUid {
-			uid := strconv.Itoa(int(stat.Uid))
-			if u, err := user.LookupId(uid); err != nil {
-				props = append(props, fmt.Sprintf("%-8s", uid))
+		if ok && opts.ShowUid {
+			uidStr := strconv.Itoa(int(uid))
+			if u, err := user.LookupId(uidStr); err != nil {
+				props = append(props, fmt.Sprintf("%-8s", uidStr))
 			} else {
 				props = append(props, fmt.Sprintf("%-8s", u.Username))
 			}
 		}
 		// Gorup/Gid
 		// TODO: support groupname
-		if opts.ShowGid {
-			gid := strconv.Itoa(int(stat.Gid))
-			props = append(props, fmt.Sprintf("%-4s", gid))
+		if ok && opts.ShowGid {
+			gidStr := strconv.Itoa(int(gid))
+			props = append(props, fmt.Sprintf("%-4s", gidStr))
 		}
 		// Size
 		if opts.ByteSize || opts.UnitSize {

--- a/stat_unix.go
+++ b/stat_unix.go
@@ -1,0 +1,20 @@
+//+build !plan9,!windows
+
+package tree
+
+import (
+	"os"
+	"syscall"
+)
+
+func getStat(fi os.FileInfo) (ok bool, inode, device, uid, gid uint64) {
+	sys := fi.Sys()
+	if sys == nil {
+		return false, 0, 0, 0, 0
+	}
+	stat, ok := sys.(*syscall.Stat_t)
+	if !ok {
+		return false, 0, 0, 0, 0
+	}
+	return true, uint64(stat.Ino), uint64(stat.Dev), uint64(stat.Uid), uint64(stat.Gid)
+}

--- a/stat_unsupported.go
+++ b/stat_unsupported.go
@@ -1,0 +1,9 @@
+//+build plan9 windows
+
+package tree
+
+import "os"
+
+func getStat(fi os.FileInfo) (ok bool, inode, device, uid, gid uint64) {
+	return false, 0, 0, 0, 0
+}


### PR DESCRIPTION
This was done by factoring platform specific functions and constants
into their own files with build constraints.

This also makes sure that if FileInfo.Sys() returns nil it doesn't
crash.

The compileall.sh shell script can be used to test that it compiles on
all platforms.