### PR TITLE
Add option to override the default ANSIColor style for a given path

### DIFF
--- a/color.go
+++ b/color.go
@@ -22,6 +22,11 @@ const (
 	White
 )
 
+// ANSIColorFormat
+func ANSIColorFormat(style string, s string) string {
+	return fmt.Sprintf("%s[%sm%s%s[%dm", Escape, style, s, Escape, Reset)
+}
+
 // ANSIColor
 func ANSIColor(node *Node, s string) string {
 	var style string
@@ -58,7 +63,7 @@ func ANSIColor(node *Node, s string) string {
 	default:
 		return s
 	}
-	return fmt.Sprintf("%s[%sm%s%s[%dm", Escape, style, s, Escape, Reset)
+	return ANSIColorFormat(style, s)
 }
 
 // case-insensitive contains helper

--- a/node.go
+++ b/node.go
@@ -71,6 +71,16 @@ type Options struct {
 	// Graphics
 	NoIndent bool
 	Colorize bool
+	// Color defaults to ANSIColor()
+	Color func(*Node, string) string
+}
+
+func (opts *Options) color(node *Node, s string) string {
+	f := opts.Color
+	if f == nil {
+		f = ANSIColor
+	}
+	return f(node, s)
 }
 
 // New get path and create new node(root).
@@ -179,6 +189,11 @@ func (node *Node) sort(opts *Options) {
 			sort.Sort(ByFunc{node.nodes, fn})
 		}
 	}
+}
+
+// Path returns the Node's absolute path
+func (node *Node) Path() string {
+	return node.path
 }
 
 // Print nodes based on the given configuration.
@@ -302,7 +317,7 @@ func (node *Node) print(indent string, opts *Options) {
 	}
 	// Colorize
 	if opts.Colorize {
-		name = ANSIColor(node, name)
+		name = opts.color(node, name)
 	}
 	// IsSymlink
 	if node.Mode()&os.ModeSymlink == os.ModeSymlink {
@@ -316,7 +331,7 @@ func (node *Node) print(indent string, opts *Options) {
 		}
 		fi, err := opts.Fs.Stat(targetPath)
 		if opts.Colorize && fi != nil {
-			vtarget = ANSIColor(&Node{FileInfo: fi, path: vtarget}, vtarget)
+			vtarget = opts.color(&Node{FileInfo: fi, path: vtarget}, vtarget)
 		}
 		name = fmt.Sprintf("%s -> %s", name, vtarget)
 		// Follow symbolic links like directories


### PR DESCRIPTION
This is useful when using the tree package with non-file resources.