### PR TITLE
Add Options: prune + matchdirs

### DIFF
--- a/node.go
+++ b/node.go
@@ -116,7 +116,7 @@ func (node *Node) Visit(opts *Options) (dirs, files int) {
 		return
 	}
 	// MatchDirs option
-	var dirMatch = false
+	var dirMatch bool
 	if node.depth != 0 && opts.MatchDirs {
 		// then disable prune and pattern for immediate children
 		if opts.Pattern != "" {

--- a/node.go
+++ b/node.go
@@ -177,13 +177,11 @@ func (node *Node) match(pattern string, opt *Options) bool {
 	if opt.IgnoreCase {
 		prefix = "(?i)"
 	}
-
 	search := node.Name()
-	re, err := regexp.Compile(prefix + pattern)
-	if strings.Contains(re.String(), "*") {
+	if strings.Contains(pattern, "*") {
 		search = node.path
 	}
-
+	re, err := regexp.Compile(prefix + pattern)
 	return err == nil && re.FindString(search) != ""
 }
 

--- a/node.go
+++ b/node.go
@@ -146,7 +146,7 @@ func (node *Node) Visit(opts *Options) (dirs, files int) {
 		if nnode.IsDir() && opts.Prune && f == 0 {
 			continue
 		} else if nnode.IsDir() && opts.MatchDirs && opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
-			return
+			continue
 		}
 		if nnode.err == nil && !nnode.IsDir() {
 			// "dirs only" option
@@ -184,7 +184,7 @@ func (node *Node) match(pattern string, opt *Options) bool {
 		search = node.path
 	}
 
-	fmt.Printf("search: %s, regex: %s, match: '%s' \n", search, re.String(), re.FindString(search))
+	// fmt.Printf("search: %s, regex: %s, match: '%s' \n", search, re.String(), re.FindString(search))
 	return err == nil && re.FindString(search) != ""
 }
 

--- a/node.go
+++ b/node.go
@@ -49,6 +49,7 @@ type Options struct {
 	DeepLevel  int
 	Pattern    string
 	IPattern   string
+	Prune      bool
 	// File
 	ByteSize bool
 	UnitSize bool
@@ -130,6 +131,10 @@ func (node *Node) Visit(opts *Options) (dirs, files int) {
 			vpaths: node.vpaths,
 		}
 		d, f := nnode.Visit(opts)
+		// "prune" option, hide empty directories
+		if opts.Prune && nnode.IsDir() && f == 0 {
+			continue
+		}
 		if nnode.err == nil && !nnode.IsDir() {
 			// "dirs only" option
 			if opts.DirsOnly {

--- a/node.go
+++ b/node.go
@@ -142,13 +142,15 @@ func (node *Node) Visit(opts *Options) (dirs, files int) {
 			vpaths: node.vpaths,
 		}
 		d, f := nnode.Visit(opts)
-		// "prune" option, hide empty directories
-		if nnode.IsDir() && opts.Prune && f == 0 {
-			continue
-		} else if nnode.IsDir() && opts.MatchDirs && opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
-			continue
-		}
-		if nnode.err == nil && !nnode.IsDir() {
+		if nnode.IsDir() {
+			// "prune" option, hide empty directories
+			if opts.Prune && f == 0 {
+				continue
+			}
+			if opts.MatchDirs && opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
+				continue
+			}
+		} else if nnode.err == nil {
 			// "dirs only" option
 			if opts.DirsOnly {
 				continue

--- a/node.go
+++ b/node.go
@@ -184,7 +184,6 @@ func (node *Node) match(pattern string, opt *Options) bool {
 		search = node.path
 	}
 
-	// fmt.Printf("search: %s, regex: %s, match: '%s' \n", search, re.String(), re.FindString(search))
 	return err == nil && re.FindString(search) != ""
 }
 

--- a/node_test.go
+++ b/node_test.go
@@ -149,7 +149,18 @@ var listTests = []treeTest{
 	{"ignore-case", &Options{Fs: fs, OutFile: out, Pattern: "(A)", IgnoreCase: true}, `root
 ├── a
 └── c
-`, 1, 1}}
+`, 1, 1},
+	{"ignore-case + prune", &Options{Fs: fs, OutFile: out, Pattern: "(A)", Prune: true, IgnoreCase: true}, `root
+└── a
+`, 0, 1},
+	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(a)", Prune: true}, `root
+└── a
+`, 0, 1},
+	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(d|e)", Prune: true}, `root
+└── c
+    ├── d
+    └── e
+`, 1, 2}}
 
 func TestSimple(t *testing.T) {
 	root := &file{

--- a/node_test.go
+++ b/node_test.go
@@ -111,56 +111,86 @@ var listTests = []treeTest{
 ├── b
 └── c
     ├── d
-    └── e
-`, 1, 4},
+    ├── e
+    └── g
+        ├── h
+        └── i
+`, 2, 6},
 	{"all", &Options{Fs: fs, OutFile: out, All: true, NoSort: true}, `root
 ├── a
 ├── b
 └── c
     ├── d
     ├── e
-    └── .f
-`, 1, 5},
+    ├── .f
+    └── g
+        ├── h
+        └── i
+`, 2, 7},
 	{"dirs", &Options{Fs: fs, OutFile: out, DirsOnly: true}, `root
 └── c
-`, 1, 0},
+    └── g
+`, 2, 0},
 	{"fullPath", &Options{Fs: fs, OutFile: out, FullPath: true}, `root
 ├── root/a
 ├── root/b
 └── root/c
     ├── root/c/d
-    └── root/c/e
-`, 1, 4},
+    ├── root/c/e
+    └── root/c/g
+        ├── root/c/g/h
+        └── root/c/g/i
+`, 2, 6},
 	{"deepLevel", &Options{Fs: fs, OutFile: out, DeepLevel: 1}, `root
 ├── a
 ├── b
 └── c
 `, 1, 2},
-	{"pattern", &Options{Fs: fs, OutFile: out, Pattern: "(a|e)"}, `root
+	{"pattern", &Options{Fs: fs, OutFile: out, Pattern: "(a|e|i)"}, `root
 ├── a
 └── c
-    └── e
-`, 1, 2},
-	{"ipattern", &Options{Fs: fs, OutFile: out, IPattern: "(a|e)"}, `root
+    ├── e
+    └── g
+        └── i
+`, 2, 3},
+	{"ipattern", &Options{Fs: fs, OutFile: out, IPattern: "(a|e|i)"}, `root
 ├── b
 └── c
-    └── d
-`, 1, 2},
+    ├── d
+    └── g
+        └── h
+`, 2, 3},
 	{"ignore-case", &Options{Fs: fs, OutFile: out, Pattern: "(A)", IgnoreCase: true}, `root
 ├── a
 └── c
-`, 1, 1},
+    └── g
+`, 2, 1},
 	{"ignore-case + prune", &Options{Fs: fs, OutFile: out, Pattern: "(A)", Prune: true, IgnoreCase: true}, `root
 └── a
 `, 0, 1},
 	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(a)", Prune: true}, `root
 └── a
 `, 0, 1},
+	{"include pattern + matchdirs + c", &Options{Fs: fs, OutFile: out, Pattern: "c", MatchDirs: true}, `root
+└── c
+    ├── d
+    ├── e
+    └── g
+`, 2, 2},
+	{"include pattern + matchdirs + c*", &Options{Fs: fs, OutFile: out, Pattern: "*c*", MatchDirs: true}, `root
+└── c
+    ├── d
+    ├── e
+    └── g
+        ├── h
+        └── i
+`, 2, 2},
 	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(d|e)", Prune: true}, `root
 └── c
     ├── d
     └── e
-`, 1, 2}}
+`, 1, 2},
+}
 
 func TestSimple(t *testing.T) {
 	root := &file{
@@ -176,6 +206,14 @@ func TestSimple(t *testing.T) {
 					{name: "d", size: 50},
 					{name: "e", size: 50},
 					{name: ".f", size: 0},
+					{
+						name: "g",
+						size: 100,
+						files: []*file{
+							{name: "h", size: 50},
+							{name: "i", size: 50},
+						},
+					},
 				},
 			},
 		},
@@ -188,7 +226,7 @@ func TestSimple(t *testing.T) {
 			t.Errorf("wrong dir count for test %q:\ngot:\n%d\nexpected:\n%d", test.name, d, test.dirs)
 		}
 		if f != test.files {
-			t.Errorf("wrong dir count for test %q:\ngot:\n%d\nexpected:\n%d", test.name, d, test.files)
+			t.Errorf("wrong file count for test %q:\ngot:\n%d\nexpected:\n%d", test.name, f, test.files)
 		}
 		inf.Print(test.opts)
 		if !out.equal(test.expected) {

--- a/node_test.go
+++ b/node_test.go
@@ -109,24 +109,28 @@ var listTests = []treeTest{
 	{"basic", &Options{Fs: fs, OutFile: out}, `root
 ├── a
 ├── b
-└── c
-    ├── d
-    ├── e
-    └── g
-        ├── h
-        └── i
-`, 2, 6},
+├── c
+│   ├── d
+│   ├── e
+│   ├── g
+│   │   ├── h
+│   │   └── i
+│   └── k
+└── j
+`, 2, 8},
 	{"all", &Options{Fs: fs, OutFile: out, All: true, NoSort: true}, `root
 ├── a
 ├── b
-└── c
-    ├── d
-    ├── e
-    ├── .f
-    └── g
-        ├── h
-        └── i
-`, 2, 7},
+├── c
+│   ├── d
+│   ├── e
+│   ├── .f
+│   ├── g
+│   │   ├── h
+│   │   └── i
+│   └── k
+└── j
+`, 2, 9},
 	{"dirs", &Options{Fs: fs, OutFile: out, DirsOnly: true}, `root
 └── c
     └── g
@@ -134,74 +138,103 @@ var listTests = []treeTest{
 	{"fullPath", &Options{Fs: fs, OutFile: out, FullPath: true}, `root
 ├── root/a
 ├── root/b
-└── root/c
-    ├── root/c/d
-    ├── root/c/e
-    └── root/c/g
-        ├── root/c/g/h
-        └── root/c/g/i
-`, 2, 6},
+├── root/c
+│   ├── root/c/d
+│   ├── root/c/e
+│   ├── root/c/g
+│   │   ├── root/c/g/h
+│   │   └── root/c/g/i
+│   └── root/c/k
+└── root/j
+`, 2, 8},
 	{"deepLevel", &Options{Fs: fs, OutFile: out, DeepLevel: 1}, `root
 ├── a
 ├── b
-└── c
-`, 1, 2},
-	{"pattern", &Options{Fs: fs, OutFile: out, Pattern: "a|e|i"}, `root
+├── c
+└── j
+`, 1, 3},
+	{"pattern (a|e|i)", &Options{Fs: fs, OutFile: out, Pattern: "(a|e|i)"}, `root
 ├── a
 └── c
     ├── e
     └── g
         └── i
 `, 2, 3},
-	{"pattern 0 files", &Options{Fs: fs, OutFile: out, Pattern: "x"}, `root
+	{"pattern (x) + 0 files", &Options{Fs: fs, OutFile: out, Pattern: "(x)"}, `root
 └── c
     └── g
 `, 2, 0},
-	{"ipattern", &Options{Fs: fs, OutFile: out, IPattern: "a|e|i"}, `root
+	{"ipattern (a|e|i)", &Options{Fs: fs, OutFile: out, IPattern: "(a|e|i)"}, `root
 ├── b
-└── c
-    ├── d
-    └── g
-        └── h
-`, 2, 3},
-	{"ignore-case", &Options{Fs: fs, OutFile: out, Pattern: "(A)", IgnoreCase: true}, `root
+├── c
+│   ├── d
+│   ├── g
+│   │   └── h
+│   └── k
+└── j
+`, 2, 5},
+	{"pattern (A) + ignore-case", &Options{Fs: fs, OutFile: out, Pattern: "(A)", IgnoreCase: true}, `root
 ├── a
 └── c
     └── g
 `, 2, 1},
-	{"ignore-case + prune", &Options{Fs: fs, OutFile: out, Pattern: "(A)", Prune: true, IgnoreCase: true}, `root
+	{"pattern (A) + ignore-case + prune", &Options{Fs: fs, OutFile: out, Pattern: "(A)", Prune: true, IgnoreCase: true}, `root
 └── a
 `, 0, 1},
-	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(a)", Prune: true}, `root
+	{"pattern (a) + prune", &Options{Fs: fs, OutFile: out, Pattern: "(a)", Prune: true}, `root
 └── a
 `, 0, 1},
-	{"include pattern + matchdirs + c", &Options{Fs: fs, OutFile: out, Pattern: "(c)", MatchDirs: true}, `root
+	{"pattern (c) + matchdirs", &Options{Fs: fs, OutFile: out, Pattern: "(c)", MatchDirs: true}, `root
 └── c
     ├── d
     ├── e
-    └── g
-`, 2, 2},
-	{"include pattern + matchdirs + c*", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", MatchDirs: true}, `root
+    ├── g
+    └── k
+`, 2, 3},
+	{"pattern (c.*) + matchdirs", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", MatchDirs: true}, `root
 └── c
     ├── d
     ├── e
-    └── g
-        ├── h
-        └── i
-`, 2, 4},
-	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(d|e)", Prune: true}, `root
+    ├── g
+    │   ├── h
+    │   └── i
+    └── k
+`, 2, 5},
+	{"ipattern (c) + matchdirs", &Options{Fs: fs, OutFile: out, IPattern: "(c)", MatchDirs: true}, `root
+├── a
+├── b
+└── j
+`, 0, 3},
+	{"ipattern (g) + matchdirs", &Options{Fs: fs, OutFile: out, IPattern: "(g)", MatchDirs: true}, `root
+├── a
+├── b
+├── c
+│   ├── d
+│   ├── e
+│   └── k
+└── j
+`, 1, 6},
+	{"ipattern (a|e|i|h) + matchdirs + prune", &Options{Fs: fs, OutFile: out, IPattern: "(a|e|i|h)", MatchDirs: true, Prune: true}, `root
+├── b
+├── c
+│   ├── d
+│   └── k
+└── j
+`, 1, 4},
+	{"pattern (d|e) + prune", &Options{Fs: fs, OutFile: out, Pattern: "(d|e)", Prune: true}, `root
 └── c
     ├── d
     └── e
 `, 1, 2},
-	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", Prune: true, MatchDirs: true}, `root
+	{"pattern (c.*) + matchdirs + prune ", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", Prune: true, MatchDirs: true}, `root
 └── c
     ├── d
     ├── e
-    └── g
-        ├── h
-        └── i
-`, 2, 4},
+    ├── g
+    │   ├── h
+    │   └── i
+    └── k
+`, 2, 5},
 }
 
 func TestSimple(t *testing.T) {
@@ -226,8 +259,10 @@ func TestSimple(t *testing.T) {
 							{name: "i", size: 50},
 						},
 					},
+					{name: "k", size: 50},
 				},
 			},
+			{name: "j", size: 50},
 		},
 	}
 	fs.clean().addFile(root.name, root)

--- a/node_test.go
+++ b/node_test.go
@@ -146,14 +146,18 @@ var listTests = []treeTest{
 ├── b
 └── c
 `, 1, 2},
-	{"pattern", &Options{Fs: fs, OutFile: out, Pattern: "(a|e|i)"}, `root
+	{"pattern", &Options{Fs: fs, OutFile: out, Pattern: "a|e|i"}, `root
 ├── a
 └── c
     ├── e
     └── g
         └── i
 `, 2, 3},
-	{"ipattern", &Options{Fs: fs, OutFile: out, IPattern: "(a|e|i)"}, `root
+	{"pattern 0 files", &Options{Fs: fs, OutFile: out, Pattern: "x"}, `root
+└── c
+    └── g
+`, 2, 0},
+	{"ipattern", &Options{Fs: fs, OutFile: out, IPattern: "a|e|i"}, `root
 ├── b
 └── c
     ├── d
@@ -171,25 +175,33 @@ var listTests = []treeTest{
 	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(a)", Prune: true}, `root
 └── a
 `, 0, 1},
-	{"include pattern + matchdirs + c", &Options{Fs: fs, OutFile: out, Pattern: "c", MatchDirs: true}, `root
+	{"include pattern + matchdirs + c", &Options{Fs: fs, OutFile: out, Pattern: "(c)", MatchDirs: true}, `root
 └── c
     ├── d
     ├── e
     └── g
 `, 2, 2},
-	{"include pattern + matchdirs + c*", &Options{Fs: fs, OutFile: out, Pattern: "*c*", MatchDirs: true}, `root
+	{"include pattern + matchdirs + c*", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", MatchDirs: true}, `root
 └── c
     ├── d
     ├── e
     └── g
         ├── h
         └── i
-`, 2, 2},
+`, 2, 4},
 	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(d|e)", Prune: true}, `root
 └── c
     ├── d
     └── e
 `, 1, 2},
+	{"include pattern + prune", &Options{Fs: fs, OutFile: out, Pattern: "(c.*)", Prune: true, MatchDirs: true}, `root
+└── c
+    ├── d
+    ├── e
+    └── g
+        ├── h
+        └── i
+`, 2, 4},
 }
 
 func TestSimple(t *testing.T) {


### PR DESCRIPTION
Given a tree structure of the following,

```
/tmp/tree/
├── a
├── b
└── c
    ├── d
    ├── e
    └── g
        ├── h
        └── i
```

the additional tree options `prune` and `matchdirs` have the following behavior as documented from the `man tree` pages.

1. Prune
```
       --prune
              Makes tree prune empty directories from the output, useful when used in conjunction with -P or -I.
              See BUGS AND NOTES below for more information on this option.
```

```
# before without --prune
tree -P A --ignore-case /tmp/tree/
/tmp/tree/
├── a
└── c
    └── g

# after with --prune
tree -P A --ignore-case --prune /tmp/tree/
/tmp/tree/
└── a
```

2. Matchdirs
```
       --matchdirs
              If a match pattern is specified by the -P option, this will cause the pattern  to  be  applied  to
              directory names (in addition to filenames).  In the event of a match on the directory name, match‐
              ing is disabled for the directory's contents. If the --prune option is used,  empty  folders  that
              match the pattern will not be pruned.
```

```
# before without --matchdirs
tree -P c /tmp/tree/
/tmp/tree/
└── c
    └── g

tree -P 'c*' /tmp/tree/
/tmp/tree/
└── c
    └── g

# after with --matchdirs
tree -P c --matchdirs /tmp/tree/
/tmp/tree/
└── c
    ├── d
    ├── e
    └── g

tree -P 'c*' --matchdirs /tmp/tree/
/tmp/tree/
└── c
    ├── d
    ├── e
    └── g
        ├── h
        └── i
```