### PR TITLE
Fix nil pointer exception in Visit on stat error and Go modernisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 draft
 coverage
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ arch:
 language: go
 sudo: false
 go:
-  - 1.13.x
-  - 1.14.x
-  - 1.15.x
+  - 1.18.x
+  - 1.19.x
+  - 1.20.x
   - tip
 matrix:
   allow_failures:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/a8m/tree
+
+go 1.15

--- a/node.go
+++ b/node.go
@@ -142,26 +142,28 @@ func (node *Node) Visit(opts *Options) (dirs, files int) {
 			vpaths: node.vpaths,
 		}
 		d, f := nnode.Visit(opts)
-		if nnode.IsDir() {
-			// "prune" option, hide empty directories
-			if opts.Prune && f == 0 {
-				continue
-			}
-			if opts.MatchDirs && opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
-				continue
-			}
-		} else if nnode.err == nil {
-			// "dirs only" option
-			if opts.DirsOnly {
-				continue
-			}
-			// Pattern matching
-			if !dirMatch && opts.Pattern != "" && !nnode.match(opts.Pattern, opts) {
-				continue
-			}
-			// IPattern matching
-			if opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
-				continue
+		if nnode.err == nil {
+			if nnode.IsDir() {
+				// "prune" option, hide empty directories
+				if opts.Prune && f == 0 {
+					continue
+				}
+				if opts.MatchDirs && opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
+					continue
+				}
+			} else {
+				// "dirs only" option
+				if opts.DirsOnly {
+					continue
+				}
+				// Pattern matching
+				if !dirMatch && opts.Pattern != "" && !nnode.match(opts.Pattern, opts) {
+					continue
+				}
+				// IPattern matching
+				if opts.IPattern != "" && nnode.match(opts.IPattern, opts) {
+					continue
+				}
 			}
 		}
 		node.nodes = append(node.nodes, nnode)


### PR DESCRIPTION
This contains 4 commits

- Fix nil pointer exception in Visit on stat error

> Fix nil pointer exception in Visit on stat error
>   
> Before this change, if an error occurred when stat-ing a file, it
> could cause a nil-pointer exception error in Visit.
>   
> This error was introduced in
>   
>     ce3525c Add prune and matchdirs options (#18)
>   
> Which refactored the error check into the wrong place.
>    
> See: https://forum.rclone.org/t/error-with-build-v1-61-1-tree-command-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference/35922/

And some Go modernisation fixes

- Convert to Go modules
- Update CI to recent Go versions
- Add emacs save files to .gitignore
