### PR TITLE
Fix and test printing and sorting with nodes where stat had failed

### DIFF
--- a/csort_bsd.go
+++ b/csort_bsd.go
@@ -8,6 +8,9 @@ import (
 )
 
 func CTimeSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	s1, ok1 := f1.Sys().(*syscall.Stat_t)
 	s2, ok2 := f2.Sys().(*syscall.Stat_t)
 	// If this type of node isn't an os node then revert to ModSort

--- a/csort_unix.go
+++ b/csort_unix.go
@@ -1,4 +1,5 @@
-//+build linux openbsd dragonfly android solaris
+//go:build linux || openbsd || dragonfly || android || solaris
+// +build linux openbsd dragonfly android solaris
 
 package tree
 
@@ -8,6 +9,9 @@ import (
 )
 
 func CTimeSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	s1, ok1 := f1.Sys().(*syscall.Stat_t)
 	s2, ok2 := f2.Sys().(*syscall.Stat_t)
 	// If this type of node isn't an os node then revert to ModSort

--- a/node.go
+++ b/node.go
@@ -254,7 +254,11 @@ func (node *Node) print(indent string, opts *Options) {
 		if msgs := strings.Split(err, ": "); len(msgs) > 1 {
 			err = msgs[1]
 		}
-		fmt.Printf("%s [%s]\n", node.path, err)
+		name := node.path
+		if !opts.FullPath {
+			name = filepath.Base(name)
+		}
+		fmt.Fprintf(opts.OutFile, "%s [%s]\n", name, err)
 		return
 	}
 	if !node.IsDir() {

--- a/sort.go
+++ b/sort.go
@@ -17,22 +17,38 @@ func (b ByFunc) Less(i, j int) bool {
 type SortFunc func(f1, f2 os.FileInfo) bool
 
 func ModSort(f1, f2 os.FileInfo) bool {
+	// This ensures any nil os.FileInfos sort at the end
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	return f1.ModTime().Before(f2.ModTime())
 }
 
 func DirSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	return f1.IsDir() && !f2.IsDir()
 }
 
 func SizeSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	return f1.Size() < f2.Size()
 }
 
 func NameSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	return f1.Name() < f2.Name()
 }
 
 func VerSort(f1, f2 os.FileInfo) bool {
+	if f1 == nil || f2 == nil {
+		return f2 == nil
+	}
 	return NaturalLess(f1.Name(), f2.Name())
 }
 


### PR DESCRIPTION
Before this change tree would crash with nil pointer exceptions in
various places if a node had stat fail on it.

This also corrects the writing of the error message to make it go to
the tree output rather than stdout.
