### PR TITLE
Print the `ModTime` year if the file wasn't modified this year

### DIFF
--- a/node.go
+++ b/node.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Node represent some node in the tree
@@ -75,6 +76,7 @@ type Options struct {
 	Colorize bool
 	// Color defaults to ANSIColor()
 	Color func(*Node, string) string
+	Now   time.Time
 }
 
 func (opts *Options) color(node *Node, s string) string {
@@ -303,7 +305,17 @@ func (node *Node) print(indent string, opts *Options) {
 		}
 		// Last modification
 		if opts.LastMod {
-			props = append(props, node.ModTime().Format("Jan 02 15:04"))
+			t := opts.Now
+			if t.IsZero() {
+				t = time.Now()
+			}
+
+			format := "Jan 02 15:04"
+			if node.ModTime().Year() != t.Year() {
+				format = "Jan 02  2006"
+			}
+
+			props = append(props, node.ModTime().Format(format))
 		}
 		// Print properties
 		if len(props) > 0 {

--- a/node_test.go
+++ b/node_test.go
@@ -388,9 +388,9 @@ c
 ├── [-rwxr-xr-x]  b
 └── [-rw-rw-rw-]  c
 `, 0, 3},
-	{"lastMod", &Options{Fs: fs, OutFile: out, LastMod: true}, `root
+	{"lastMod", &Options{Fs: fs, OutFile: out, LastMod: true, Now: time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)}, `root
 ├── [Feb 11 00:00]  a
-├── [Jan 28 00:00]  b
+├── [Jan 28  2006]  b
 └── [Jul 12 00:00]  c
 `, 0, 3}}
 


### PR DESCRIPTION
Right now this implementation of `tree` does not print the year the file was modified. Steve Baker's `tree` prints the month, day, and time if the file was modified in the present year and the month, day, and year if it wasn't. A user familiar with Steve Baker's `tree` who sees a `LastMod: true` tree generated by this implementation can mistakenly think every file was modified in the present year. My PR changes this implementation to match Steve Baker's `tree`.

## Demo

First, build `cmd/tree/tree`. In the repository directory run the commands:

```fish
> mkdir test
> cd test
> touch foo
> touch --date @1605450000 bar
> tree -D
[Jan  4 09:28]  .
├── [Nov 15  2020]  bar
└── [Jan  4 09:28]  foo

0 directories, 2 files
> ../cmd/tree/tree -D
.
├── [Nov 15 17:20]  bar
└── [Jan 04 09:28]  foo

0 directories, 2 files
```

Apply the patch and rebuild.

```fish
> ../cmd/tree/tree -D
.
├── [Nov 15  2020]  bar
└── [Jan 04 09:28]  foo

0 directories, 2 files
```